### PR TITLE
Run no UI cli

### DIFF
--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -8,7 +8,7 @@ namespace APIDocGenerator
     {
         private readonly ILogger<MainPage> _logger;
         private readonly MainViewModel _viewModel;
-
+        private readonly string[] _commandLineArgs;
         public MainPage(ILogger<MainPage> logger, MainViewModel viewModel)
         {
             InitializeComponent();
@@ -16,6 +16,45 @@ namespace APIDocGenerator
 
             _viewModel = viewModel;
             _logger = logger;
+            _commandLineArgs = Environment.GetCommandLineArgs();
+            if(_commandLineArgs.Length == 4)
+            {
+                RunCommandLineArgs();
+            }
+        }
+
+        private void RunCommandLineArgs()
+        {
+            string source = _commandLineArgs[1];
+            string target = _commandLineArgs[2];
+            string name = _commandLineArgs[3];
+
+            if (!Directory.Exists(source))
+            {
+                _logger.LogError($"Source directory \"{source}\" is invalid.");
+            }
+            else if (!Directory.Exists(target)) 
+            {
+                _logger.LogError($"Target directory \"{target}\" is invalid.");
+            }
+            else
+            {
+                _viewModel.SelectedSource = source;
+                _viewModel.SelectedDestination = target;
+                _viewModel.FileName = name;
+
+                try
+                {
+                    _viewModel.GenerateDocument();
+                    _logger.LogInformation($"\"{name}.docx\" created successfully at {DateTime.Now:u}.");
+                } 
+                catch(Exception ex)
+                {
+                    _logger.LogError($"Command line run failed to generate document: {ex}");
+                }
+            } 
+
+            Application.Current?.Quit();
         }
 
         private void SourceFolderPathCompletedEvent(object sender, EventArgs e)

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -7,7 +7,7 @@ namespace APIDocGenerator
     public partial class MainPage : ContentPage
     {
         private readonly ILogger<MainPage> _logger;
-        private MainViewModel _viewModel;
+        private readonly MainViewModel _viewModel;
 
         public MainPage(ILogger<MainPage> logger, MainViewModel viewModel)
         {

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -31,7 +31,7 @@ namespace APIDocGenerator
             {
                 options.FolderPath = $"{AppDomain.CurrentDomain.BaseDirectory}\\__Logs";
                 options.MinLevel = LogLevel.Information;
-                options.RetainDays = 30;
+                options.RetainDays = 15;
             });
             
 #if DEBUG

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -128,7 +128,7 @@ namespace APIDocGenerator.ViewModels
 
                     if (!parsedControllerRoute.Contains("api"))
                     {
-                        parsedControllerRoute = $"/api{parsedControllerRoute}";
+                        parsedControllerRoute = $"api/{parsedControllerRoute}";
                     }
 
                     string paragraphHeader = $"{controllerName} {versionString}";


### PR DESCRIPTION
Added ability to run the application from a CLI and pass in the source directory, target directory, and file name. Technically the UI still pops up and is open while running, but closes on completion (or error). Should be sufficient for running in a self hosted repo and build runner.