### PR TITLE
Add Document Generation Support for Swagger JSON Files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# CS8618: Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+dotnet_diagnostic.CS8618.severity = none

--- a/APIDocGenerator.csproj
+++ b/APIDocGenerator.csproj
@@ -66,6 +66,7 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.71" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.71" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 
 </Project>

--- a/APIDocGenerator.csproj
+++ b/APIDocGenerator.csproj
@@ -30,13 +30,14 @@
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<!--<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>-->
+		<!--<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>-->
+		<!--<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>-->
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+		<!--<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>-->
 		<WindowsPackageType Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">None</WindowsPackageType>
+		<WindowsPackageType>None</WindowsPackageType>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -42,7 +42,7 @@
                 <RadioButton Content="Use Swagger generated json file" 
                              TextColor="#E8B00F" 
                              HorizontalOptions="Center" 
-                             IsChecked="{Binding UseJsonFileIsOn}"
+                             IsChecked="{Binding UseJsonFile}"
                              CheckedChanged="OnSourceTypeRadioButtonChanged"/>
                 <RadioButton Content="Use Controller files" 
                              TextColor="#E8B00F" 

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -60,7 +60,7 @@
 
                 <Entry x:Name="destinationFolder"
                Text="{Binding SelectedDestination}"
-               Placeholder="Enter destination folder path"
+               Placeholder="Enter document file destination folder"
                Completed="DestinationFolderPathCompletedEvent"
                Style="{StaticResource entryStyle}"/>
             </HorizontalStackLayout>

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -34,19 +34,44 @@
         <VerticalStackLayout
             Spacing="25"
             VerticalOptions="Center">
-            <Label  Text="Select folder for controllers and destination for document"
+            <Label  Text="Select your source and the destination folder for document"
                 TextColor="#E8B00F"
                 HorizontalOptions="Center"
                 SemanticProperties.HeadingLevel="Level1" />
+            <HorizontalStackLayout Spacing="30" HorizontalOptions="Center" >
+                <RadioButton Content="Use Swagger generated json file" 
+                             TextColor="#E8B00F" 
+                             HorizontalOptions="Center" 
+                             IsChecked="{Binding UseJsonFileIsOn}"
+                             CheckedChanged="OnSourceTypeRadioButtonChanged"/>
+                <RadioButton Content="Use Controller files" 
+                             TextColor="#E8B00F" 
+                             HorizontalOptions="Center"
+                             CheckedChanged="OnSourceTypeRadioButtonChanged"/>
+            </HorizontalStackLayout>
+            
             <HorizontalStackLayout HorizontalOptions="Center"
-                               Spacing="30">
+                               Spacing="30" IsVisible="{Binding JsonFileSelectionIsVisible}">
+                <Button Command="{Binding SelectJsonSourceFileCommand}"
+                Text="Select Source"
+                HorizontalOptions="Center"
+                Style="{StaticResource buttonStyle}"/>
+                <Entry x:Name="sourceFile"
+               Text="{Binding SelectedSource}"
+               Placeholder="Select .json file"
+               Completed="SourceJsonFilePathCompletedEvent"
+               Style="{StaticResource entryStyle}"/>
+            </HorizontalStackLayout>
+            
+            <HorizontalStackLayout HorizontalOptions="Center"
+                               Spacing="30" IsVisible="{Binding FolderSelectionIsVisible}">
                 <Button Command="{Binding SelectSourceFolderCommand}"
                 Text="Select Source"
                 HorizontalOptions="Center"
                 Style="{StaticResource buttonStyle}"/>
                 <Entry x:Name="sourceFolder"
                Text="{Binding SelectedSource}"
-               Placeholder="Enter source folder path"
+               Placeholder="Select controllers root folder"
                Completed="SourceFolderPathCompletedEvent"
                Style="{StaticResource entryStyle}"/>
             </HorizontalStackLayout>

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -13,15 +13,17 @@ namespace APIDocGenerator
         {
             _viewModel = viewModel;
             _commandLineArgs = Environment.GetCommandLineArgs();
+            _logger = logger;
+
             if (_commandLineArgs.Length == 4)
             {
                 RunCommandLineArgs();
             }
-
-            InitializeComponent();
-            BindingContext = viewModel;
-
-            _logger = logger;
+            else
+            {
+                InitializeComponent();
+                BindingContext = viewModel;
+            }
         }
 
         private async void RunCommandLineArgs()
@@ -45,6 +47,7 @@ namespace APIDocGenerator
                 _viewModel.SelectedSource = source;
                 _viewModel.SelectedDestination = target;
                 _viewModel.FileName = name;
+                _viewModel.UseJsonFile = sourceIsJsonFile;
 
                 try
                 {

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -66,6 +66,12 @@ namespace APIDocGenerator
             _viewModel.SelectedSource = path;
         }
 
+        private void SourceJsonFilePathCompletedEvent(object sender, EventArgs e)
+        {
+            string path = (((Entry)sender).Text);
+            _viewModel.SelectedSource = path;
+        }
+
         private void DestinationFolderPathCompletedEvent(object sender, EventArgs e)
         {
             string path = ((Entry)sender).Text;
@@ -89,6 +95,11 @@ namespace APIDocGenerator
         {
             string fileName = ((Entry)sender).Text;
             _viewModel.FileName = fileName;
+        }
+
+        private void OnSourceTypeRadioButtonChanged(object sender, CheckedChangedEventArgs e)
+        {
+            _viewModel.SwapSourceSelectionOption();
         }
     }
 

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -30,9 +30,11 @@ namespace APIDocGenerator
             string target = _commandLineArgs[2];
             string name = _commandLineArgs[3];
 
-            if (!Directory.Exists(source))
+            bool sourceIsJsonFile = source.LastIndexOf(".json") >= 0;
+
+            if ((sourceIsJsonFile && !File.Exists(source)) || (!sourceIsJsonFile && !Directory.Exists(source)))
             {
-                _logger.LogError("Source directory \"{source}\" is invalid.", source);
+                _logger.LogError("Source file or directory \"{source}\" is invalid.", source);
             }
             else if (!Directory.Exists(target)) 
             {

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -25,9 +25,6 @@ namespace APIDocGenerator
             builder.Services.AddSingleton<IFolderPicker>(FolderPicker.Default);
             builder.Services.AddSingleton<IFilePicker>(FilePicker.Default);
 
-            builder.Services.AddScoped<FileReaderService>();
-            builder.Services.AddScoped<TextParserService>();
-
             builder.Logging.AddStreamingFileLogger(options =>
             {
                 options.FolderPath = $"{AppDomain.CurrentDomain.BaseDirectory}\\__Logs";

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -23,6 +23,7 @@ namespace APIDocGenerator
             builder.Services.AddSingleton<MainPage>();
             builder.Services.AddSingleton<MainViewModel>();
             builder.Services.AddSingleton<IFolderPicker>(FolderPicker.Default);
+            builder.Services.AddSingleton<IFilePicker>(FilePicker.Default);
 
             builder.Services.AddScoped<FileReaderService>();
             builder.Services.AddScoped<TextParserService>();

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,5 +1,4 @@
-﻿using APIDocGenerator.Services;
-using APIDocGenerator.ViewModels;
+﻿using APIDocGenerator.ViewModels;
 using CommunityToolkit.Maui;
 using CommunityToolkit.Maui.Storage;
 using MetroLog.MicrosoftExtensions;

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -388,7 +388,7 @@ namespace APIDocGenerator.Services
 
             if (details.Responses != null)
             {
-
+                container.AppendChild(CreateNewResponseSection(details.Responses));
             }
 
 
@@ -496,6 +496,14 @@ namespace APIDocGenerator.Services
             return container;
         }
 
+        private Run CreateNewResponseSection(Dictionary<string, Response> responses)
+        {
+            Run container = new Run();
+
+
+            return container;
+        }
+
         /// <summary>
         /// Creates a heading for a controller that will contain the various available endpoints.
         /// </summary>
@@ -574,12 +582,22 @@ namespace APIDocGenerator.Services
 
                         if (propSchema.Items != null)
                         {
-                            for (int i = 0; i < numTabs; i++)
+                            for (int i = 0; i < numTabs + 1; i++)
                             {
                                 propertyRun.AppendChild(new TabChar());
                             }
-                            propertyRun.AppendChild(new TabChar());
-                            string valueText = !string.IsNullOrEmpty(propSchema.Items.Ref) ? "object" : string.IsNullOrEmpty(propSchema.Format) ? propSchema.Type : propSchema.Format;
+
+                            if (!string.IsNullOrEmpty(propSchema.Items.Description))
+                            {
+                                propertyRun.AppendChild(Format.CreateTextLine(propSchema.Items.Description, JSON_FONT_SIZE));
+                                propertyRun.AppendChild(new CarriageReturn());
+                                for (int i = 0; i < numTabs + 1; i++)
+                                {
+                                    propertyRun.AppendChild(new TabChar());
+                                }
+                            }
+
+                            string valueText = !string.IsNullOrEmpty(propSchema.Items.Ref) ? "object" : string.IsNullOrEmpty(propSchema.Items.Format) ? propSchema.Items.Type : propSchema.Items.Format;
                             propertyRun.AppendChild(Format.CreateLabelValuePair("Items: ", valueText, JSON_FONT_SIZE));
                             propertyRun.AppendChild(new CarriageReturn());
                             

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -242,24 +242,20 @@ namespace APIDocGenerator.Services
         /// <returns></returns>
         public Task GenerateFromJson(string json)
         {
-            try
+            RootApiJson? apiRoot = JsonConvert.DeserializeObject<RootApiJson>(json);
+
+            if (apiRoot == null)
             {
-                RootApiJson? apiRoot = JsonConvert.DeserializeObject<RootApiJson>(json);
-
-                if (apiRoot != null)
-                {
-                    throw new Exception("Error encountered parsing the JSON file.");
-                }
-
-                CreateBlankDocument();
-                AddTitleLine(DocumentName);
-            }
-            catch (Exception ex) 
-            { 
-                
+                throw new Exception("Error encountered parsing the JSON file.");
             }
 
+            CreateBlankDocument();
+            string version = !string.IsNullOrEmpty(apiRoot.Info?.Version) ? $" v{apiRoot.Info.Version}" : string.Empty;
+            AddTitleLine($"{DocumentName}{version}");
 
+
+
+            Save();
             return Task.CompletedTask;
         }
 

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -6,6 +6,8 @@ using DocumentFormat.OpenXml;
 using Microsoft.Maui.Storage;
 using System.Diagnostics;
 using Newtonsoft.Json.Linq;
+using APIDocGenerator.Models.JsonParse;
+using Newtonsoft.Json;
 
 namespace APIDocGenerator.Services
 {
@@ -28,7 +30,7 @@ namespace APIDocGenerator.Services
         /// </summary>
         private void CreateBlankDocument()
         {
-            Document = WordprocessingDocument.Create($"{_destinationFolder}{Path.DirectorySeparatorChar}{DocumentName}.docx", WordprocessingDocumentType.Document);
+            Document = WordprocessingDocument.Create($"{_destinationFolder}{System.IO.Path.DirectorySeparatorChar}{DocumentName}.docx", WordprocessingDocumentType.Document);
             MainPart = Document.AddMainDocumentPart();
             MainPart.Document = new Document();
             Body = MainPart.Document.AppendChild(new Body());
@@ -238,18 +240,26 @@ namespace APIDocGenerator.Services
         /// 
         /// </summary>
         /// <returns></returns>
-        public Task GenerateFromJson(JObject json)
+        public Task GenerateFromJson(string json)
         {
-            CreateBlankDocument();
-            AddTitleLine(DocumentName);
-
-            JToken? paths = json.GetValue("paths");
-            JToken? schemas = json.GetValue("components")?;
-
-            if (paths != null)
+            try
             {
-                foreach (var path in paths) { }
+                RootApiJson? apiRoot = JsonConvert.DeserializeObject<RootApiJson>(json);
+
+                if (apiRoot != null)
+                {
+                    throw new Exception("Error encountered parsing the JSON file.");
+                }
+
+                CreateBlankDocument();
+                AddTitleLine(DocumentName);
             }
+            catch (Exception ex) 
+            { 
+                
+            }
+
+
             return Task.CompletedTask;
         }
 

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -242,7 +242,7 @@ namespace APIDocGenerator.Services
         }
 
         /// <summary>
-        /// 
+        /// Generates a new document from a Swagger generated JSON string.
         /// </summary>
         /// <returns></returns>
         public Task GenerateFromJson(string json)
@@ -392,7 +392,7 @@ namespace APIDocGenerator.Services
         }
 
         /// <summary>
-        /// 
+        /// Create a new Parameter section for a HTTP request type.
         /// </summary>
         /// <returns></returns>
         private static Run CreateNewParameterSection(IEnumerable<Parameter> parameters)
@@ -451,7 +451,7 @@ namespace APIDocGenerator.Services
         }
 
         /// <summary>
-        /// 
+        /// Creates a new HTTP POST request body section, including schema obj formatting.
         /// </summary>
         /// <param name="body"></param>
         /// <returns></returns>
@@ -522,7 +522,8 @@ namespace APIDocGenerator.Services
         }
 
         /// <summary>
-        /// 
+        /// Creates a formatted section for a given schema, recursively drilling down to sub-properties. Number of tab indentations
+        /// is tracked so I don't have to mess with a bulleted list cause it's a giant pita in OpenXMl.
         /// </summary>
         /// <param name="schemaToFormat"></param>
         /// <param name="numTabs"></param>
@@ -537,6 +538,7 @@ namespace APIDocGenerator.Services
 
             Run container = new Run();
 
+            // pretty much always going to be true, since even arrays are wrapped in brackets
             if (schema.Type == "object")
             {
                 foreach (KeyValuePair<string, Schema> objProps in schema.Properties)
@@ -593,7 +595,7 @@ namespace APIDocGenerator.Services
         }
 
         /// <summary>
-        /// 
+        /// Finds the requested json component from the reference string. This assumes a singular list of components.
         /// </summary>
         /// <param name="refString"></param>
         /// <returns></returns>

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -244,10 +244,8 @@ namespace APIDocGenerator.Services
             AddTitleLine(DocumentName);
 
             JToken? paths = json.GetValue("paths");
-            JToken? components = json.GetValue("components");
-            while (paths.CreateReader().Read())
-            {
-            }
+            JToken? schemas = json.GetValue("components")?;
+
             if (paths != null)
             {
                 foreach (var path in paths) { }

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -449,10 +449,10 @@ namespace APIDocGenerator.Services
             };
             locationValue.Append(locValueProps);
             locationValue.AppendChild(new Text { Text = param.In, Space = SpaceProcessingModeValues.Preserve });
-            locationValue.AppendChild(new Break());
 
             if (param.Required)
             {
+                locationValue.AppendChild(new Break());
                 Run required = paragraph.AppendChild(new Run());
                 RunProperties reqProps = new RunProperties
                 {
@@ -463,7 +463,6 @@ namespace APIDocGenerator.Services
                 required.AppendChild(new TabChar());
                 required.AppendChild(new TabChar());
                 required.AppendChild(new Text { Text = "Required", Space = SpaceProcessingModeValues.Preserve });
-                required.AppendChild(new Break());
             }
 
             return paragraph;
@@ -488,7 +487,6 @@ namespace APIDocGenerator.Services
 
             string headingText = $"{controllerName} Endpoints";
             run.Append(props);
-            run.AppendChild(new Break());
             run.AppendChild(new Text() { Text = headingText });
             run.AppendChild(new Break());
             paragraph.AppendChild(run);

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -272,7 +272,7 @@ namespace APIDocGenerator.Services
 
                 if(routeDetails.Get != null)
                 {
-                    Paragraph get = CreateNewRequestTypeSection("GET", routeDetails.Get);
+                    Run get = CreateNewRequestTypeSection("GET", routeDetails.Get);
                     routeHeader.AppendChild(get);
 
                     controllerName = routeDetails.Get.Tags.First();           
@@ -280,7 +280,7 @@ namespace APIDocGenerator.Services
 
                 if (routeDetails.Put != null) 
                 {
-                    Paragraph put = CreateNewRequestTypeSection("PUT", routeDetails.Put);
+                    Run put = CreateNewRequestTypeSection("PUT", routeDetails.Put);
                     routeHeader.AppendChild(put);
 
                     controllerName = routeDetails.Put.Tags.First();
@@ -288,7 +288,7 @@ namespace APIDocGenerator.Services
 
                 if (routeDetails.Post != null)
                 {
-                    Paragraph post = CreateNewRequestTypeSection("POST", routeDetails.Post);
+                    Run post = CreateNewRequestTypeSection("POST", routeDetails.Post);
                     routeHeader.AppendChild(post);
 
                     controllerName = routeDetails.Post.Tags.First();
@@ -296,7 +296,7 @@ namespace APIDocGenerator.Services
 
                 if (routeDetails.Delete != null)
                 {
-                    Paragraph delete = CreateNewRequestTypeSection("DELETE", routeDetails.Delete);
+                    Run delete = CreateNewRequestTypeSection("DELETE", routeDetails.Delete);
                     routeHeader.AppendChild(delete);
 
                     controllerName = routeDetails.Delete.Tags.First();
@@ -325,15 +325,9 @@ namespace APIDocGenerator.Services
         private static Paragraph CreateNewRouteSection(string path)
         {
             Paragraph paragraph = new Paragraph();
-            Run run = new Run();
-            RunProperties props = new RunProperties();
-            props.Bold = new Bold();
-            props.FontSize = new FontSize() { Val = HEADING_FONT_SIZE };
-
-            run.Append(props);
-            run.AppendChild(new Text() { Text = path, Space = SpaceProcessingModeValues.Preserve });
-            run.AppendChild(new Break());
-            paragraph.AppendChild(run);
+            Run run =paragraph.AppendChild(new Run());
+            run.AppendChild(Format.CreateBoldTextLine(path, HEADING_FONT_SIZE));
+            run.AppendChild(new CarriageReturn());
 
             return paragraph;
         }
@@ -345,10 +339,10 @@ namespace APIDocGenerator.Services
         /// <param name="type"></param>
         /// <param name="details"></param>
         /// <returns></returns>
-        private Paragraph CreateNewRequestTypeSection(string type, RequestType details)
+        private Run CreateNewRequestTypeSection(string type, RequestType details)
         {
-            Paragraph paragraph = new Paragraph();
-            Run run = paragraph.AppendChild(new Run());
+            Run container = new Run();
+            Run run = container.AppendChild(new Run());
             RunProperties props = new RunProperties();
             props.FontSize = new FontSize() { Val = TEXT_FONT_SIZE };
             props.Bold = new Bold();
@@ -373,49 +367,46 @@ namespace APIDocGenerator.Services
             run.AppendChild(new Text() { Text = $"{type}: ", Space = SpaceProcessingModeValues.Preserve });
             if (!string.IsNullOrEmpty(details.Summary))
             {
-                Run next = paragraph.AppendChild(new Run());
-                RunProperties nextProps = new RunProperties();
-                nextProps.FontSize = new FontSize { Val = TEXT_FONT_SIZE };
-                next.Append(nextProps);
-                next.AppendChild(new Text() { Text = $"{details.Summary}", Space = SpaceProcessingModeValues.Preserve });
-                next.AppendChild(new Break());
+                Run next = container.AppendChild(new Run());
+                next.AppendChild(Format.CreateTextLine(details.Summary, TEXT_FONT_SIZE));
+                next.AppendChild(new CarriageReturn());
             }
             else
             {
-                run.AppendChild(new Break());
+                run.AppendChild(new CarriageReturn());
             }
 
             if (details.Parameters != null)
             {
-                paragraph.AppendChild(CreateNewParameterSection(details.Parameters));
+                container.AppendChild(CreateNewParameterSection(details.Parameters));
             }
 
             if (details.RequestBody != null) 
             {
-                paragraph.AppendChild(CreateNewRequestBodySection(details.RequestBody));
+                container.AppendChild(CreateNewRequestBodySection(details.RequestBody));
             }
 
 
 
-            return paragraph;
+            return container;
         }
 
         /// <summary>
         /// 
         /// </summary>
         /// <returns></returns>
-        private static Paragraph CreateNewParameterSection(IEnumerable<Parameter> parameters)
+        private static Run CreateNewParameterSection(IEnumerable<Parameter> parameters)
         {
-            Paragraph paragraph = new Paragraph();
-            Run paramSection = paragraph.AppendChild(new Run());
+            Run container = new Run();
+            Run paramSection = container.AppendChild(new Run());
             paramSection.AppendChild(Format.CreateBoldTextLine("Parameters", TEXT_FONT_SIZE));
-            paramSection.AppendChild(new Break());
+            paramSection.AppendChild(new CarriageReturn());
 
             foreach (Parameter param in parameters)
             {
-                paragraph.AppendChild(CreateNewParameter(param));
+                container.AppendChild(CreateNewParameter(param));
             }
-            return paragraph;
+            return container;
         }
 
         /// <summary>
@@ -430,7 +421,7 @@ namespace APIDocGenerator.Services
             container.AppendChild(new TabChar());
 
             string typeText = string.IsNullOrEmpty(param.Schema.Format) ? param.Schema.Type : param.Schema.Format;
-            container.AppendChild(Format.CreateLabelValuePair(param.Name, typeText, JSON_FONT_SIZE));
+            container.AppendChild(Format.CreateLabelValuePair($"{param.Name} : ", typeText, JSON_FONT_SIZE));
             container.AppendChild(new Break());
 
             if (!string.IsNullOrEmpty(param.Description))
@@ -464,89 +455,40 @@ namespace APIDocGenerator.Services
         /// </summary>
         /// <param name="body"></param>
         /// <returns></returns>
-        private Paragraph CreateNewRequestBodySection(RequestBody body)
+        private Run CreateNewRequestBodySection(RequestBody body)
         {
-            Paragraph paragraph = new Paragraph();
-            Run reqBody = paragraph.AppendChild(new Run());
-            RunProperties reqBodyProps = new RunProperties
-            {
-                Bold = new Bold(),
-                FontSize = new FontSize { Val = TEXT_FONT_SIZE }
-            };
-            reqBody.Append(reqBodyProps);
-            reqBody.AppendChild(new Text { Text = "Request Body", Space = SpaceProcessingModeValues.Preserve });
-            reqBody.AppendChild(new Break());
+            Run container = new Run();
+            Run reqBody = container.AppendChild(new Run());
+            reqBody.AppendChild(Format.CreateBoldTextLine("Request Body", TEXT_FONT_SIZE));
+            reqBody.AppendChild(new CarriageReturn());
 
             if (!string.IsNullOrEmpty(body.Description))
             {
-                Run content = paragraph.AppendChild(new Run());
-                RunProperties contentProps = new RunProperties
-                {
-                    FontSize = new FontSize { Val = JSON_FONT_SIZE }
-                };
-                content.Append(contentProps);
-                content.AppendChild(new TabChar());
-                content.AppendChild(new Text { Text = body.Description, Space = SpaceProcessingModeValues.Preserve });
-                content.AppendChild(new Break());
+                Run description = container.AppendChild(new Run());
+                description.AppendChild(new TabChar());
+                description.AppendChild(Format.CreateTextLine(body.Description, JSON_FONT_SIZE));
+                description.AppendChild(new CarriageReturn());
             }
             
-            if (body.Content.TryGetValue("application/json", out Content? value))
+            if (body.Content.TryGetValue("application/json", out Content? appJsonContent))
             {
-                Run appJson = paragraph.AppendChild(new Run());
-                RunProperties appJsonProps = new RunProperties
-                {
-                    FontSize = new FontSize { Val = JSON_FONT_SIZE },
-                    Bold = new Bold()
-                };
-                appJson.Append(appJsonProps);
+                Run appJson = container.AppendChild(new Run());
                 appJson.AppendChild(new TabChar());
-                appJson.AppendChild(new Text { Text = "application/json", Space = SpaceProcessingModeValues.Preserve });
-                appJson.AppendChild(new Break());
-
-                Schema jsonSchema = value.Schema;
-                if (!string.IsNullOrEmpty(jsonSchema.Ref))
-                {
-                    jsonSchema = GetSchemaComponent(jsonSchema.Ref);
-                }
-
-                Run content = paragraph.AppendChild(new Run());
-                RunProperties contentProps = new RunProperties
-                {
-                    FontSize = new FontSize { Val = JSON_FONT_SIZE }
-                };
-                content.AppendChild(new TabChar());
-                content.AppendChild(new TabChar());
-                content.AppendChild(CreateFormattedSchema(jsonSchema));
-
-
-                //foreach(KeyValuePair<string,Schema> objProps in jsonSchema.Properties)
-                //{
-                //    Run name = paragraph.AppendChild(new Run());
-                //    RunProperties nameProps = new RunProperties
-                //    {
-                //        Bold = new Bold(),
-                //        FontSize = new FontSize { Val = JSON_FONT_SIZE }
-                //    };
-                //    name.Append(nameProps);
-                //    name.AppendChild(new TabChar());
-                //    name.AppendChild(new TabChar());
-                //    name.AppendChild(new Text { Text = $"{objProps.Key}: ", Space = SpaceProcessingModeValues.Preserve });
-
-                //    Run val = paragraph.AppendChild(new Run());
-                //    RunProperties valProps = new RunProperties
-                //    {
-                //        FontSize = new FontSize { Val = JSON_FONT_SIZE }
-                //    };
-                //    val.Append(valProps);
-                //    string typeText = string.IsNullOrEmpty(objProps.Value.Format) ? objProps.Value.Type : objProps.Value.Format;
-                //    val.AppendChild(new Text { Text = typeText, Space = SpaceProcessingModeValues.Preserve });
-
-
-                //}
+                appJson.AppendChild(Format.CreateBoldTextLine("application/json", JSON_FONT_SIZE));
+                appJson.AppendChild(new CarriageReturn());
+                appJson.AppendChild(CreateFormattedSchema(appJsonContent.Schema, 2));
             }
 
+            if(body.Content.TryGetValue("multipart/form-data", out Content? formData))
+            {
+                Run formRun = container.AppendChild(new Run());
+                formRun.AppendChild(new TabChar());
+                formRun.AppendChild(Format.CreateBoldTextLine("multipart/form-data", JSON_FONT_SIZE));
+                formRun.AppendChild(new CarriageReturn());
+                formRun.AppendChild(CreateFormattedSchema(formData.Schema, 2));
+            }
 
-            return paragraph;
+            return container;
         }
 
         /// <summary>
@@ -579,7 +521,13 @@ namespace APIDocGenerator.Services
             return paragraph;
         }
 
-        private Paragraph CreateFormattedSchema(Schema schemaToFormat, string name = "")
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="schemaToFormat"></param>
+        /// <param name="numTabs"></param>
+        /// <returns></returns>
+        private Run CreateFormattedSchema(Schema schemaToFormat, int numTabs = 0)
         {
             Schema schema = schemaToFormat;
             if (!string.IsNullOrEmpty(schema.Ref))
@@ -587,11 +535,7 @@ namespace APIDocGenerator.Services
                 schema = GetSchemaComponent(schema.Ref);
             }
 
-            string schemaName = string.IsNullOrEmpty(name) ? schema.Name : name;
-
-
-            Paragraph paragraph = new Paragraph();
-            paragraph.AppendChild(Format.CreateLabelValuePair(schemaName, schema.Type, JSON_FONT_SIZE));
+            Run container = new Run();
 
             if (schema.Type == "object")
             {
@@ -600,83 +544,52 @@ namespace APIDocGenerator.Services
                     string propName = objProps.Key;
                     Schema propSchema = objProps.Value;
 
+                    Run propertyRun = container.AppendChild(new Run());
+                    for (int i = 0; i < numTabs; i++)
+                    {
+                        propertyRun.AppendChild(new TabChar());
+                    }
+
                     if (!string.IsNullOrEmpty(propSchema.Ref))
                     {
                         propSchema = GetSchemaComponent(propSchema.Ref);
-                        paragraph.AppendChild(CreateFormattedSchema(propSchema));
+                        Run propParagraph = propertyRun.AppendChild(new Run());
+                        propParagraph.AppendChild(CreateFormattedSchema(propSchema, numTabs+1));
 
                     } else
                     {
-                        Run nameText = paragraph.AppendChild(new Run());
-                        RunProperties nameProps = new RunProperties
-                        {
-                            Bold = new Bold(),
-                            FontSize = new FontSize { Val = JSON_FONT_SIZE }
-                        };
-                        nameText.Append(nameProps);
-                        nameText.AppendChild(new Text { Text = $"{propName}: ", Space = SpaceProcessingModeValues.Preserve });
-
-                        Run val = paragraph.AppendChild(new Run());
-                        RunProperties valProps = new RunProperties
-                        {
-                            FontSize = new FontSize { Val = JSON_FONT_SIZE }
-                        };
-                        val.Append(valProps);
                         string typeText = string.IsNullOrEmpty(propSchema.Format) ? propSchema.Type : propSchema.Format;
-                        val.AppendChild(new Text { Text = typeText, Space = SpaceProcessingModeValues.Preserve });
-                        val.AppendChild(new Break());
-
-                        Run desc = paragraph.AppendChild(new Run());
-                        RunProperties descProps = new RunProperties
+                        propertyRun.AppendChild(Format.CreateLabelValuePair($"{propName}: ", typeText, JSON_FONT_SIZE));
+                        propertyRun.AppendChild(new CarriageReturn());
+                        if (!string.IsNullOrEmpty(propSchema.Description))
                         {
-                            FontSize = new FontSize { Val = JSON_FONT_SIZE }
-                        };
-                        desc.Append(descProps);
-                        desc.AppendChild(new TabChar());
-                        desc.AppendChild(new Text { Text = propSchema.Description, Space = SpaceProcessingModeValues.Preserve });
-                        desc.AppendChild(new Break());
+                            for (int i = 0; i < numTabs; i++)
+                            {
+                                propertyRun.AppendChild(new TabChar());
+                            }
+                            propertyRun.AppendChild(Format.CreateTextLine(propSchema.Description, JSON_FONT_SIZE));
+                            propertyRun.AppendChild(new CarriageReturn());
+                        }
 
                         if (propSchema.Items != null)
                         {
-                            Run items = paragraph.AppendChild(new Run());
-                            RunProperties itemsProp = new RunProperties
+                            for (int i = 0; i < numTabs; i++)
                             {
-                                FontSize = new FontSize { Val = JSON_FONT_SIZE }
-                            };
-                            items.Append(itemsProp);
-                            items.AppendChild(new TabChar());
-                            items.AppendChild(CreateFormattedSchema(propSchema.Items));
+                                propertyRun.AppendChild(new TabChar());
+                            }
+                            propertyRun.AppendChild(new TabChar());
+                            string valueText = !string.IsNullOrEmpty(propSchema.Items.Ref) ? "object" : string.IsNullOrEmpty(propSchema.Format) ? propSchema.Type : propSchema.Format;
+                            propertyRun.AppendChild(Format.CreateLabelValuePair("Items: ", valueText, JSON_FONT_SIZE));
+                            propertyRun.AppendChild(new CarriageReturn());
+                            
+                            Run itemsRun = propertyRun.AppendChild(new Run());
+                            itemsRun.AppendChild(CreateFormattedSchema(propSchema.Items, numTabs+2));
                         }
                     }
                 }
             }
 
-            //if(schema.Type == "array")
-            //{
-            //    Run items = paragraph.AppendChild(new Run());
-            //    RunProperties itemsProps = new RunProperties
-            //    {
-            //        FontSize = new FontSize { Val = JSON_FONT_SIZE },
-            //        Bold = new Bold()
-            //    };
-            //    items.Append(itemsProps);
-            //    items.AppendChild(new TabChar());
-            //    items.AppendChild(new TabChar());
-            //    items.AppendChild(new Text { Text = "items: ", Space = SpaceProcessingModeValues.Preserve });
-
-            //    Run itemsType = paragraph.AppendChild(new Run());
-            //    RunProperties itemsTypeProps = new RunProperties
-            //    {
-            //        FontSize = new FontSize { Val = JSON_FONT_SIZE },
-            //    };
-            //    itemsType.Append(itemsTypeProps);
-            //    itemsType.AppendChild(new Text { Text = schema.Items.Type, Space = SpaceProcessingModeValues.Preserve });
-            //    itemsType.AppendChild(new Break());
-
-
-            //}
-
-            return paragraph;
+            return container;
         }
 
         /// <summary>

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -386,6 +386,11 @@ namespace APIDocGenerator.Services
                 container.AppendChild(CreateNewRequestBodySection(details.RequestBody));
             }
 
+            if (details.Responses != null)
+            {
+
+            }
+
 
 
             return container;
@@ -507,17 +512,11 @@ namespace APIDocGenerator.Services
             Justification centered = new Justification() { Val = JustificationValues.Center };
             paragraph.ParagraphProperties?.Append(centered);
 
-            Run run = new Run();
-            RunProperties props = new RunProperties();
-            props.Bold = new Bold();
-            props.FontSize = new FontSize() { Val = TITLE_FONT_SIZE };
-
+            Run run = paragraph.AppendChild(new Run());
             string headingText = $"{controllerName} Endpoints";
-            run.Append(props);
-            run.AppendChild(new Text() { Text = headingText });
-            run.AppendChild(new Break());
-            paragraph.AppendChild(run);
-
+            run.AppendChild(Format.CreateBoldTextLine(headingText, TITLE_FONT_SIZE));
+            run.AppendChild(new CarriageReturn());
+            
             return paragraph;
         }
 

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -517,8 +517,8 @@ namespace APIDocGenerator.Services
                     break;
             }
 
-            run.Append(props);
-            run.AppendChild(new Text() { Text = $"{type}: ", Space = SpaceProcessingModeValues.Preserve });
+            run.AppendChild(Format.CreateTextLine($"{type}: ", props));
+
             if (!string.IsNullOrEmpty(details.Summary))
             {
                 Run next = container.AppendChild(new Run());
@@ -721,11 +721,6 @@ namespace APIDocGenerator.Services
         /// <param name="paragraphs"></param>
         private void CompileDocument(Dictionary<string, List<OpenXmlElement>> paragraphs)
         {
-            //foreach(KeyValuePair<string, OpenXmlElement> components in _componentBulletLists)
-            //{
-            //    Body.AppendChild(components.Value);
-            //}
-
             foreach (KeyValuePair<string, List<OpenXmlElement>> items in paragraphs) 
             {
                 OpenXmlElement heading = CreateNewControllerHeading(items.Key);

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -1,21 +1,23 @@
-﻿using DocumentFormat.OpenXml.Packaging;
+﻿using APIDocGenerator.Models.JsonParse;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using Newtonsoft.Json;
 using Color = DocumentFormat.OpenXml.Wordprocessing.Color;
 using FontSize = DocumentFormat.OpenXml.Wordprocessing.FontSize;
-using DocumentFormat.OpenXml;
-using Microsoft.Maui.Storage;
-using System.Diagnostics;
-using Newtonsoft.Json.Linq;
-using APIDocGenerator.Models.JsonParse;
-using Newtonsoft.Json;
-using DocumentFormat.OpenXml.Bibliography;
-using System.Speech.Synthesis;
 
 namespace APIDocGenerator.Services
 {
     public class DocumentGenerator
     {
+        private const string TITLE_FONT_SIZE = "40";
+        private const string HEADING_FONT_SIZE = "32";
+        private const string TEXT_FONT_SIZE = "24";
+        private const string JSON_FONT_SIZE = "18";
+
         private string _destinationFolder;
+        private Components _jsonComponents;
+
         public string DocumentName { get; private set; }
         public WordprocessingDocument Document { get; private set; }
         public MainDocumentPart MainPart {  get; private set; }
@@ -53,7 +55,7 @@ namespace APIDocGenerator.Services
             Run run = new Run();
             RunProperties props = new RunProperties();
             props.Bold = new Bold();
-            props.FontSize = new FontSize() { Val = "32"};
+            props.FontSize = new FontSize() { Val = HEADING_FONT_SIZE};
             
             run.Append(props);
             run.AppendChild(new Break());
@@ -71,7 +73,7 @@ namespace APIDocGenerator.Services
             Paragraph last = Body.Elements<Paragraph>().Last();         
             Run run = last.AppendChild(new Run());
             RunProperties props = new RunProperties();
-            props.FontSize = new FontSize() { Val = "24" };
+            props.FontSize = new FontSize() { Val = TEXT_FONT_SIZE };
 
             run.AppendChild(props);
             run.AppendChild(new Break());
@@ -94,14 +96,14 @@ namespace APIDocGenerator.Services
             {
                 Run run = last.AppendChild(new Run());
                 RunProperties props = new RunProperties();
-                props.FontSize = new FontSize() { Val = "24" };
+                props.FontSize = new FontSize() { Val = TEXT_FONT_SIZE };
                 props.Bold = new Bold();
                 run.AppendChild(props);
                 run.AppendChild(new Text() { Text = line.Key, Space = SpaceProcessingModeValues.Preserve });
 
                 Run next = last.AppendChild(new Run());
                 RunProperties nextProps = new RunProperties();
-                props.FontSize = new FontSize() { Val = "24" };
+                props.FontSize = new FontSize() { Val = TEXT_FONT_SIZE };
                 next.AppendChild(nextProps);
                 next.AppendChild(new Text() { Text = line.Value, Space = SpaceProcessingModeValues.Preserve });
                 next.AppendChild(new Break());
@@ -118,7 +120,7 @@ namespace APIDocGenerator.Services
             Paragraph last = Body.Elements<Paragraph>().Last();
             Run run = last.AppendChild(new Run());
             RunProperties props = new RunProperties();
-            props.FontSize = new FontSize() { Val = "24" };
+            props.FontSize = new FontSize() { Val = TEXT_FONT_SIZE };
             props.Bold = new Bold();
 
             switch (type)
@@ -143,7 +145,7 @@ namespace APIDocGenerator.Services
             Run next = last.AppendChild(new Run());
             RunProperties nextProps = new RunProperties();
             nextProps.Bold = new Bold();
-            nextProps.FontSize = new FontSize() { Val = "24" };
+            nextProps.FontSize = new FontSize() { Val = TEXT_FONT_SIZE };
 
             next.Append(nextProps);
             next.AppendChild(new Text() { Text = $"/{text}", Space = SpaceProcessingModeValues.Preserve });
@@ -168,7 +170,7 @@ namespace APIDocGenerator.Services
             Run run = new Run();
             RunProperties props = new RunProperties();
             props.Bold = new Bold();
-            props.FontSize = new FontSize() { Val = "40" };
+            props.FontSize = new FontSize() { Val = TITLE_FONT_SIZE };
 
             run.Append(props);
             run.AppendChild(new Break());
@@ -243,13 +245,14 @@ namespace APIDocGenerator.Services
         /// </summary>
         /// <returns></returns>
         public Task GenerateFromJson(string json)
-        {
+        {   
             RootApiJson? apiRoot = JsonConvert.DeserializeObject<RootApiJson>(json);
 
             if (apiRoot == null)
             {
                 throw new Exception("Error encountered parsing the JSON file.");
             }
+            _jsonComponents = apiRoot.Components;
 
             CreateBlankDocument();
             string version = !string.IsNullOrEmpty(apiRoot.Info?.Version) ? $" v{apiRoot.Info.Version}" : string.Empty;
@@ -318,10 +321,9 @@ namespace APIDocGenerator.Services
             Run run = new Run();
             RunProperties props = new RunProperties();
             props.Bold = new Bold();
-            props.FontSize = new FontSize() { Val = "32" };
+            props.FontSize = new FontSize() { Val = HEADING_FONT_SIZE };
 
             run.Append(props);
-            run.AppendChild(new Break());
             run.AppendChild(new Text() { Text = path, Space = SpaceProcessingModeValues.Preserve });
             run.AppendChild(new Break());
             paragraph.AppendChild(run);
@@ -334,7 +336,7 @@ namespace APIDocGenerator.Services
             Paragraph paragraph = new Paragraph();
             Run run = paragraph.AppendChild(new Run());
             RunProperties props = new RunProperties();
-            props.FontSize = new FontSize() { Val = "24" };
+            props.FontSize = new FontSize() { Val = TEXT_FONT_SIZE };
             props.Bold = new Bold();
 
             switch (type)
@@ -359,11 +361,10 @@ namespace APIDocGenerator.Services
             Run next = paragraph.AppendChild(new Run());
             RunProperties nextProps = new RunProperties();
             nextProps.Bold = new Bold();
-            nextProps.FontSize = new FontSize() { Val = "24" };
+            nextProps.FontSize = new FontSize() { Val = TEXT_FONT_SIZE };
 
             next.Append(nextProps);
             next.AppendChild(new Text() { Text = $"{details.Summary}", Space = SpaceProcessingModeValues.Preserve });
-            next.AppendChild(new Break());
 
             return paragraph;
         }
@@ -373,7 +374,7 @@ namespace APIDocGenerator.Services
             Paragraph paragraph = new Paragraph();
             Run run = paragraph.AppendChild(new Run());
             RunProperties props = new RunProperties();
-            props.FontSize = new FontSize() { Val = "24" };
+            props.FontSize = new FontSize() { Val = TEXT_FONT_SIZE };
             props.Bold = new Bold();
 
             return paragraph;
@@ -394,12 +395,12 @@ namespace APIDocGenerator.Services
             Run run = new Run();
             RunProperties props = new RunProperties();
             props.Bold = new Bold();
-            props.FontSize = new FontSize() { Val = "40" };
+            props.FontSize = new FontSize() { Val = TITLE_FONT_SIZE };
 
-            string headingText = $"{controllerName} Controller Routes";
+            string headingText = $"{controllerName} Endpoints";
             run.Append(props);
             run.AppendChild(new Break());
-            run.AppendChild(new Text() { Text = controllerName });
+            run.AppendChild(new Text() { Text = headingText });
             run.AppendChild(new Break());
             paragraph.AppendChild(run);
 

--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -582,52 +582,37 @@ namespace APIDocGenerator.Services
                     if (!string.IsNullOrEmpty(propSchema.Ref))
                     {
                         propSchema = GetSchemaComponent(propSchema.Ref);
-                        Run propParagraph = propertyRun.AppendChild(new Run());
-                        propParagraph.AppendChild(CreateFormattedSchema(propSchema, numTabs+1));
+                        if(propSchema == schema)
+                        {
+                            propertyRun.AppendChild(Format.CreateLabelValuePair($"{propName}: ", "Same object type as parent", JSON_FONT_SIZE));
+                            propertyRun.AppendChild(new CarriageReturn());
+                        } else
+                        {
+                            Run propParagraph = propertyRun.AppendChild(new Run());
+                            propParagraph.AppendChild(CreateFormattedSchema(propSchema, numTabs + 1));
+                        }
 
                     } else
                     {
                         propertyRun.AppendChild(Format.CreateLabelValuePair($"{propName}: ", propSchema.DisplayTypeText, JSON_FONT_SIZE));
                         propertyRun.AppendChild(new CarriageReturn());
-                        if (!string.IsNullOrEmpty(propSchema.Description))
-                        {
-                            for (int i = 0; i < numTabs; i++)
-                            {
-                                propertyRun.AppendChild(new TabChar());
-                            }
-                            propertyRun.AppendChild(Format.CreateTextLine(propSchema.Description, JSON_FONT_SIZE));
-                            propertyRun.AppendChild(new CarriageReturn());
-                        }
 
                         if (propSchema.Items != null)
                         {
                             propertyRun.AppendChild(CreateFormattedSchema(propSchema, numTabs + 1));
-                            //for (int i = 0; i < numTabs + 1; i++)
-                            //{
-                            //    propertyRun.AppendChild(new TabChar());
-                            //}
 
-                            //string valueText = !string.IsNullOrEmpty(propSchema.Items.Ref) ? "object" : string.IsNullOrEmpty(propSchema.Items.Format) ? propSchema.Items.Type : propSchema.Items.Format;
-                            //propertyRun.AppendChild(Format.CreateLabelValuePair("Array Content: ", valueText, JSON_FONT_SIZE));
-                            //propertyRun.AppendChild(new CarriageReturn());
-
-                            //if (!string.IsNullOrEmpty(propSchema.Items.Description))
-                            //{
-                            //    Paragraph desc = propertyRun.AppendChild(new Paragraph());
-
-                            //    for (int i = 0; i < numTabs + 1; i++)
-                            //    {
-                            //        desc.AppendChild(new TabChar());
-                            //    }
-                            //    desc.AppendChild(Format.CreateTextLine(propSchema.Items.Description, JSON_FONT_SIZE));
-                            //    propertyRun.AppendChild(new CarriageReturn());
-                            //}
-
-                            //if (valueText == "object")
-                            //{
-                            //    Run itemsRun = propertyRun.AppendChild(new Run());
-                            //    itemsRun.AppendChild(CreateFormattedSchema(propSchema.Items, numTabs + 2));
-                            //}
+                        } else
+                        {
+                            // if there are items, it's an array and we'll let the description fall under it
+                            if (!string.IsNullOrEmpty(propSchema.Description))
+                            {
+                                for (int i = 0; i < numTabs; i++)
+                                {
+                                    propertyRun.AppendChild(new TabChar());
+                                }
+                                propertyRun.AppendChild(Format.CreateTextLine(propSchema.Description, JSON_FONT_SIZE));
+                                propertyRun.AppendChild(new CarriageReturn());
+                            }
                         }
                     }
                 }

--- a/Models/JsonParse/ApiInfo.cs
+++ b/Models/JsonParse/ApiInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class ApiInfo
+    {
+        public string Title { get; set; }
+        public string Version { get; set; }
+    }
+}

--- a/Models/JsonParse/Components.cs
+++ b/Models/JsonParse/Components.cs
@@ -3,5 +3,6 @@
     public class Components
     {
         public Dictionary<string, Schema> Schemas { get; set; }
+        public Dictionary<string, Schema> SecuritySchemes { get; set; }
     }
 }

--- a/Models/JsonParse/Components.cs
+++ b/Models/JsonParse/Components.cs
@@ -1,0 +1,7 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class Components
+    {
+        public Dictionary<string, Schema> Schemas { get; set; }
+    }
+}

--- a/Models/JsonParse/Content.cs
+++ b/Models/JsonParse/Content.cs
@@ -2,7 +2,6 @@
 {
     public class Content
     {
-        public string Name { get; set; }
         public Schema Schema { get; set; }
     }
 }

--- a/Models/JsonParse/Content.cs
+++ b/Models/JsonParse/Content.cs
@@ -1,0 +1,8 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class Content
+    {
+        public string Name { get; set; }
+        public Schema Schema { get; set; }
+    }
+}

--- a/Models/JsonParse/Parameter.cs
+++ b/Models/JsonParse/Parameter.cs
@@ -1,0 +1,11 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class Parameter
+    {
+        public string Name { get; set; }
+        public string In {  get; set; }
+        public string Description { get; set; }
+        public bool Required { get; set; }
+        public Schema Schema { get; set; }
+    }
+}

--- a/Models/JsonParse/Path.cs
+++ b/Models/JsonParse/Path.cs
@@ -2,7 +2,6 @@
 {
     public class Path
     {
-        public string Route { get; set; }
         public RequestType? Get {  get; set; }
         public RequestType? Post { get; set; }
         public RequestType? Put { get; set; }

--- a/Models/JsonParse/Path.cs
+++ b/Models/JsonParse/Path.cs
@@ -1,0 +1,11 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class Path
+    {
+        public string Route { get; set; }
+        public RequestType? Get {  get; set; }
+        public RequestType? Post { get; set; }
+        public RequestType? Put { get; set; }
+        public RequestType? Delete { get; set; }
+    }
+}

--- a/Models/JsonParse/RequestBody.cs
+++ b/Models/JsonParse/RequestBody.cs
@@ -3,6 +3,6 @@
     public class RequestBody
     {
         public string Description { get; set; }
-
+        public Dictionary<string, Content> Content { get; set; }
     }
 }

--- a/Models/JsonParse/RequestBody.cs
+++ b/Models/JsonParse/RequestBody.cs
@@ -1,0 +1,8 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class RequestBody
+    {
+        public string Description { get; set; }
+
+    }
+}

--- a/Models/JsonParse/RequestType.cs
+++ b/Models/JsonParse/RequestType.cs
@@ -6,6 +6,6 @@
         public string Summary { get; set; }
         public IEnumerable<Parameter> Parameters { get; set; }
         public RequestBody RequestBody { get; set; }
-        public Responses Responses { get; set; }
+        public Dictionary<string, Response> Responses { get; set; }
     }
 }

--- a/Models/JsonParse/RequestType.cs
+++ b/Models/JsonParse/RequestType.cs
@@ -1,0 +1,12 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class RequestType
+    {
+        public IEnumerable<string> Tags { get; set; }
+        public string Type { get; set; }
+        public string Summary { get; set; }
+        public IEnumerable<Parameter> Parameters { get; set; }
+        public RequestBody RequestBody { get; set; }
+        public Responses Responses { get; set; }
+    }
+}

--- a/Models/JsonParse/RequestType.cs
+++ b/Models/JsonParse/RequestType.cs
@@ -3,7 +3,6 @@
     public class RequestType
     {
         public IEnumerable<string> Tags { get; set; }
-        public string Type { get; set; }
         public string Summary { get; set; }
         public IEnumerable<Parameter> Parameters { get; set; }
         public RequestBody RequestBody { get; set; }

--- a/Models/JsonParse/Response.cs
+++ b/Models/JsonParse/Response.cs
@@ -1,8 +1,7 @@
 ﻿namespace APIDocGenerator.Models.JsonParse
 {
-    public class Responses
+    public class Response
     {
-        public int ResponseCode { get; set; }
         public string Description { get; set; }
         public Dictionary<string, Content> Content { get; set; }
     }

--- a/Models/JsonParse/Responses.cs
+++ b/Models/JsonParse/Responses.cs
@@ -4,6 +4,6 @@
     {
         public int ResponseCode { get; set; }
         public string Description { get; set; }
-        public IEnumerable<Content> Content { get; set; }
+        public Dictionary<string, Content> Content { get; set; }
     }
 }

--- a/Models/JsonParse/Responses.cs
+++ b/Models/JsonParse/Responses.cs
@@ -1,0 +1,9 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class Responses
+    {
+        public int ResponseCode { get; set; }
+        public string Description { get; set; }
+        public IEnumerable<Content> Content { get; set; }
+    }
+}

--- a/Models/JsonParse/RootApiJson.cs
+++ b/Models/JsonParse/RootApiJson.cs
@@ -1,0 +1,10 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class RootApiJson
+    {
+        public string OpenApi {  get; set; }
+        public ApiInfo Info { get; set; }
+        public Dictionary<string, Path> Paths { get; set; }
+        public Components Components { get; set; }
+    }
+}

--- a/Models/JsonParse/RootApiJson.cs
+++ b/Models/JsonParse/RootApiJson.cs
@@ -4,7 +4,7 @@
     {
         public string OpenApi {  get; set; }
         public ApiInfo Info { get; set; }
-        public Dictionary<string, Path> Paths { get; set; }
+        public Dictionary<string, Route> Paths { get; set; }
         public Components Components { get; set; }
     }
 }

--- a/Models/JsonParse/Route.cs
+++ b/Models/JsonParse/Route.cs
@@ -1,6 +1,6 @@
 ﻿namespace APIDocGenerator.Models.JsonParse
 {
-    public class Path
+    public class Route
     {
         public RequestType? Get {  get; set; }
         public RequestType? Post { get; set; }

--- a/Models/JsonParse/Schema.cs
+++ b/Models/JsonParse/Schema.cs
@@ -1,0 +1,13 @@
+﻿namespace APIDocGenerator.Models.JsonParse
+{
+    public class Schema
+    {
+        public string Name { get; set; }
+        public string Type { get; set; }
+        public Schema Items { get; set; }
+        public string Description { get; set; }
+        public string Format { get; set; }
+        public bool Nullable { get; set; }
+        public bool ReadOnly { get; set; }
+    }
+}

--- a/Models/JsonParse/Schema.cs
+++ b/Models/JsonParse/Schema.cs
@@ -9,5 +9,7 @@
         public string Format { get; set; }
         public bool Nullable { get; set; }
         public bool ReadOnly { get; set; }
+        public Dictionary<string, Schema> Properties { get; set; }
+        public bool AdditionalProperties { get; set; }
     }
 }

--- a/Models/JsonParse/Schema.cs
+++ b/Models/JsonParse/Schema.cs
@@ -14,5 +14,7 @@ namespace APIDocGenerator.Models.JsonParse
         public Dictionary<string, Schema> Properties { get; set; }
         [JsonProperty(PropertyName = "$ref")]
         public string Ref { get; set; }
+        [JsonIgnore]
+        public string DisplayTypeText { get => string.IsNullOrEmpty(Format) ? Type : Format; }
     }
 }

--- a/Models/JsonParse/Schema.cs
+++ b/Models/JsonParse/Schema.cs
@@ -1,4 +1,6 @@
-﻿namespace APIDocGenerator.Models.JsonParse
+﻿using Newtonsoft.Json;
+
+namespace APIDocGenerator.Models.JsonParse
 {
     public class Schema
     {
@@ -10,6 +12,7 @@
         public bool Nullable { get; set; }
         public bool ReadOnly { get; set; }
         public Dictionary<string, Schema> Properties { get; set; }
-        public bool AdditionalProperties { get; set; }
+        [JsonProperty(PropertyName = "$ref")]
+        public string Ref { get; set; }
     }
 }

--- a/PublishCmd.txt
+++ b/PublishCmd.txt
@@ -1,1 +1,1 @@
-﻿msbuild /restore /t:Publish /p:TargetFramework=net8.0-windows10.0.19041 /p:configuration=release /p:WindowsAppSDKSelfContained=true /p:Platform="Any CPU" /p:PublishSingleFile=true /p:WindowsPackageType=None /p:RuntimeIdentifier=win10-x64
+﻿msbuild /restore /t:Publish /p:TargetFramework=net8.0-windows10.0.19041.0 /p:configuration=release /p:WindowsAppSDKSelfContained=true /p:Platform="Any CPU" /p:PublishSingleFile=true /p:WindowsPackageType=None /p:RuntimeIdentifier=win10-x64

--- a/PublishCmd.txt
+++ b/PublishCmd.txt
@@ -1,0 +1,1 @@
+﻿msbuild /restore /t:Publish /p:TargetFramework=net8.0-windows10.0.19041 /p:configuration=release /p:WindowsAppSDKSelfContained=true /p:Platform="Any CPU" /p:PublishSingleFile=true /p:WindowsPackageType=None /p:RuntimeIdentifier=win10-x64

--- a/Services/FileReaderService.cs
+++ b/Services/FileReaderService.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace APIDocGenerator.Services
 {
-    public class FileReaderService
+    public static class FileReaderService
     {
         /// <summary>
         /// Returns list of .cs files in provided directory.

--- a/Services/FormattingService.cs
+++ b/Services/FormattingService.cs
@@ -1,6 +1,5 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace APIDocGenerator.Services
 {
@@ -9,48 +8,49 @@ namespace APIDocGenerator.Services
         public static Run CreateLabelValuePair(string label, string value, string fontSize)
         {
             Run container = new Run();
-            Run labelRun = container.AppendChild(new Run());
+
             RunProperties labelProps = new RunProperties
             {
                 Bold = new Bold(),
                 FontSize = new FontSize { Val = fontSize }
             };
-            labelRun.AppendChild(labelProps);
-            labelRun.AppendChild(new Text { Text = label, Space = SpaceProcessingModeValues.Preserve });
+            container.AppendChild(CreateTextLine(label, labelProps));
 
-            Run valueRun = container.AppendChild(new Run());
+
             RunProperties valueProps = new RunProperties
             {
                 FontSize = new FontSize { Val = fontSize }
             };
-            valueRun.AppendChild(valueProps);
-            valueRun.AppendChild(new Text { Text = value, Space = SpaceProcessingModeValues.Preserve });
+            container.AppendChild(CreateTextLine(value, valueProps));
 
             return container;
         }
 
         public static Run CreateTextLine(string text, string fontSize)
         {
-            Run textRun = new Run();
             RunProperties textProps = new RunProperties
             {
                 FontSize = new FontSize { Val = fontSize }
             };
-            textRun.Append(textProps);
-            textRun.AppendChild(new Text { Text = text, Space = SpaceProcessingModeValues.Preserve });
 
-            return textRun;
+            return CreateTextLine(text, textProps);
         }
 
         public static Run CreateBoldTextLine(string text, string fontSize)
         {
-            Run textRun = new Run();
             RunProperties textProps = new RunProperties
             {
                 FontSize = new FontSize { Val = fontSize },
                 Bold = new Bold()
             };
-            textRun.Append(textProps);
+
+            return CreateTextLine(text, textProps);
+        }
+
+        public static Run CreateTextLine(string text, RunProperties props)
+        {
+            Run textRun = new Run();
+            textRun.Append(props);
             textRun.AppendChild(new Text { Text = text, Space = SpaceProcessingModeValues.Preserve });
 
             return textRun;

--- a/Services/FormattingService.cs
+++ b/Services/FormattingService.cs
@@ -1,0 +1,64 @@
+﻿using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace APIDocGenerator.Services
+{
+    public static class FormattingService
+    {
+        public static Run CreateLabelValuePair(string label, string value, string fontSize)
+        {
+            Run container = new Run();
+            Run labelRun = container.AppendChild(new Run());
+            RunProperties labelProps = new RunProperties
+            {
+                Bold = new Bold(),
+                FontSize = new FontSize { Val = fontSize }
+            };
+            labelRun.AppendChild(labelProps);
+            labelRun.AppendChild(new Text { Text = $"{label} : ", Space = SpaceProcessingModeValues.Preserve });
+
+            Run valueRun = container.AppendChild(new Run());
+            RunProperties valueProps = new RunProperties
+            {
+                FontSize = new FontSize { Val = fontSize }
+            };
+            valueRun.AppendChild(valueProps);
+            valueRun.AppendChild(new Text { Text = value, Space = SpaceProcessingModeValues.Preserve });
+
+            return container;
+        }
+
+        public static Run CreateTextLine(string text, string fontSize)
+        {
+            Run textRun = new Run();
+            RunProperties textProps = new RunProperties
+            {
+                FontSize = new FontSize { Val = fontSize }
+            };
+            textRun.Append(textProps);
+            textRun.AppendChild(new Text { Text = text, Space = SpaceProcessingModeValues.Preserve });
+
+            return textRun;
+        }
+
+        public static Run CreateBoldTextLine(string text, string fontSize)
+        {
+            Run textRun = new Run();
+            RunProperties textProps = new RunProperties
+            {
+                FontSize = new FontSize { Val = fontSize },
+                Bold = new Bold()
+            };
+            textRun.Append(textProps);
+            textRun.AppendChild(new Text { Text = text, Space = SpaceProcessingModeValues.Preserve });
+
+            return textRun;
+        }
+    }
+}

--- a/Services/FormattingService.cs
+++ b/Services/FormattingService.cs
@@ -1,5 +1,6 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace APIDocGenerator.Services
 {
@@ -53,6 +54,21 @@ namespace APIDocGenerator.Services
             textRun.AppendChild(new Text { Text = text, Space = SpaceProcessingModeValues.Preserve });
 
             return textRun;
+        }
+
+        public static Paragraph CreateBulletedListItem(int numberingId, int indent, Run text)
+        {
+            int indentUnitSize = 240;
+            string indentValue = $"{indent * indentUnitSize}";
+
+            var propNumberProps = new NumberingProperties(new NumberingLevelReference { Val = 0 }, new NumberingId { Val = numberingId });
+            var propSpaceBetween = new SpacingBetweenLines { After = "0" };
+            var propIndentation = new Indentation { Left = indentValue };
+
+            Paragraph paragraph = new Paragraph(new ParagraphProperties(propNumberProps, propSpaceBetween, propIndentation));
+            paragraph.AppendChild(text);
+
+            return paragraph;
         }
     }
 }

--- a/Services/FormattingService.cs
+++ b/Services/FormattingService.cs
@@ -1,11 +1,5 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace APIDocGenerator.Services
 {

--- a/Services/FormattingService.cs
+++ b/Services/FormattingService.cs
@@ -21,7 +21,7 @@ namespace APIDocGenerator.Services
                 FontSize = new FontSize { Val = fontSize }
             };
             labelRun.AppendChild(labelProps);
-            labelRun.AppendChild(new Text { Text = $"{label} : ", Space = SpaceProcessingModeValues.Preserve });
+            labelRun.AppendChild(new Text { Text = label, Space = SpaceProcessingModeValues.Preserve });
 
             Run valueRun = container.AppendChild(new Run());
             RunProperties valueProps = new RunProperties

--- a/Services/TextParserService.cs
+++ b/Services/TextParserService.cs
@@ -4,14 +4,14 @@ using System.Xml.Linq;
 
 namespace APIDocGenerator.Services
 {
-    public class TextParserService
+    public static class TextParserService
     {
         /// <summary>
         /// Returns a concatenated string of versions controller is available for, based on [ApiVersion] attribute.
         /// </summary>
         /// <param name="lines"></param>
         /// <returns></returns>
-        public string GetVersionInfo(IEnumerable<string> lines) {
+        public static string GetVersionInfo(IEnumerable<string> lines) {
             IEnumerable<string> versions = lines.Where(x => x.StartsWith("[ApiVersion"));
             IEnumerable<string> parsedVersions = versions.Select(x => $"v{x.Substring(x.IndexOf('(') + 1, 1)}");
 
@@ -23,7 +23,7 @@ namespace APIDocGenerator.Services
         /// </summary>
         /// <param name="line"></param>
         /// <returns></returns>
-        public (string, string) GetEndPointRouting(string line)
+        public static (string, string) GetEndPointRouting(string line)
         {
             string parsed = new StringBuilder(line).Replace("[", "").Replace("]", "").Replace("(", "").Replace(")", "").ToString();
             string[] split = parsed.Split('"');
@@ -39,7 +39,7 @@ namespace APIDocGenerator.Services
         /// </summary>
         /// <param name="lines"></param>
         /// <returns></returns>
-        public IEnumerable<string> GetLinesAtFirstEndpoint(IEnumerable<string> lines)
+        public static IEnumerable<string> GetLinesAtFirstEndpoint(IEnumerable<string> lines)
         {
             List<string> listOfLines = lines.ToList();
             string firstHttp = listOfLines.First(x => x.StartsWith("[Http"));
@@ -64,7 +64,7 @@ namespace APIDocGenerator.Services
         /// <param name="lines"></param>
         /// <param name="currIdx"></param>
         /// <returns></returns>
-        public (int, List<KeyValuePair<string, string>>) GetParsedXMLString(List<string> lines, int currIdx)
+        public static (int, List<KeyValuePair<string, string>>) GetParsedXMLString(List<string> lines, int currIdx)
         {
             int lastIdx = 0;
             for(int i = currIdx + 1; i < lines.Count; i++)

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -3,9 +3,6 @@ using CommunityToolkit.Maui.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Windows.Data.Json;
 
 namespace APIDocGenerator.ViewModels
 {
@@ -26,9 +23,7 @@ namespace APIDocGenerator.ViewModels
         [ObservableProperty]
         private bool _folderSelectionIsVisible = false;
         [ObservableProperty]
-        private bool _useJsonFileIsOn = true;
-        [ObservableProperty]
-        private bool _useControllersIsOn = false;
+        private bool _useJsonFile = true;
 
         public MainViewModel(ILogger<MainViewModel> logger, IFolderPicker folderPicker, IFilePicker filePicker)
         {
@@ -105,8 +100,8 @@ namespace APIDocGenerator.ViewModels
         /// </summary>
         public void SwapSourceSelectionOption()
         {
-            JsonFileSelectionIsVisible = UseJsonFileIsOn;
-            FolderSelectionIsVisible = !UseJsonFileIsOn;
+            JsonFileSelectionIsVisible = UseJsonFile;
+            FolderSelectionIsVisible = !UseJsonFile;
             SelectedSource = string.Empty;
         }
 
@@ -145,7 +140,7 @@ namespace APIDocGenerator.ViewModels
 
             DocumentGenerator docGenerator = new DocumentGenerator(SelectedDestination, FileName);
 
-            if (UseControllersIsOn) 
+            if (!UseJsonFile) 
             {
                 IEnumerable<FileInfo> sourceFiles = FileReaderService.GetFiles(SelectedSource);
                 await docGenerator.GenerateFromControllerFiles(sourceFiles);

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -19,6 +19,14 @@ namespace APIDocGenerator.ViewModels
         private string _selectedDestination = string.Empty;
         [ObservableProperty]
         private string _fileName = string.Empty;
+        [ObservableProperty]
+        private bool _jsonFileSelectionIsVisible = true;
+        [ObservableProperty]
+        private bool _folderSelectionIsVisible = false;
+        [ObservableProperty]
+        private bool _useJsonFileIsOn = true;
+        [ObservableProperty]
+        private bool _useControllersIsOn = false;
 
         public MainViewModel(ILogger<MainViewModel> logger, IFolderPicker folderPicker, IFilePicker filePicker, TextParserService parserService)
         {
@@ -52,6 +60,23 @@ namespace APIDocGenerator.ViewModels
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        [RelayCommand]
+        public async Task SelectJsonSourceFile(CancellationToken token)
+        {
+            IDictionary<DevicePlatform, IEnumerable<string>> fileTypes = new Dictionary<DevicePlatform, IEnumerable<string>> { { DevicePlatform.WinUI, [".json"] } };
+            FileResult? result = await _filePicker.PickAsync(new PickOptions { FileTypes = new FilePickerFileType(fileTypes) });
+
+            if(result != null)
+            {
+                SelectedSource = result.FullPath;
+            }
+        }
+
+        /// <summary>
         /// Gets user selected destination folder for the output file.
         /// </summary>
         /// <param name="token"></param>
@@ -75,6 +100,16 @@ namespace APIDocGenerator.ViewModels
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        public void SwapSourceSelectionOption()
+        {
+            JsonFileSelectionIsVisible = UseJsonFileIsOn;
+            FolderSelectionIsVisible = !UseJsonFileIsOn;
+            SelectedSource = string.Empty;
+        }
+
+        /// <summary>
         /// Generates and outputs the finalized document.
         /// </summary>
         /// <returns></returns>
@@ -83,7 +118,8 @@ namespace APIDocGenerator.ViewModels
             if (string.IsNullOrWhiteSpace(FileName))
             {
                 throw new Exception("File name must be set");
-            } else
+            } 
+            else
             {
                 if (FileName.Contains(".docx"))
                 {
@@ -103,7 +139,7 @@ namespace APIDocGenerator.ViewModels
 
             if (string.IsNullOrWhiteSpace(SelectedSource))
             {
-                throw new Exception("Controller source folder must be set");
+                throw new Exception("Source must be set");
             }
 
             IEnumerable<FileInfo> sourceFiles = FileReaderService.GetFiles(SelectedSource);

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -10,6 +10,7 @@ namespace APIDocGenerator.ViewModels
     {
         private readonly ILogger<MainViewModel> _logger;
         private readonly IFolderPicker _folderPicker;
+        private readonly IFilePicker _filePicker;
         private readonly TextParserService _parserService;
 
         [ObservableProperty]
@@ -19,10 +20,11 @@ namespace APIDocGenerator.ViewModels
         [ObservableProperty]
         private string _fileName = string.Empty;
 
-        public MainViewModel(ILogger<MainViewModel> logger, IFolderPicker folderPicker, TextParserService parserService)
+        public MainViewModel(ILogger<MainViewModel> logger, IFolderPicker folderPicker, IFilePicker filePicker, TextParserService parserService)
         {
             _logger = logger;
             _folderPicker = folderPicker;
+            _filePicker = filePicker;
             _parserService = parserService;
         }
 

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -153,8 +153,7 @@ namespace APIDocGenerator.ViewModels
             else
             {
                 string jsonContent = await File.ReadAllTextAsync(SelectedSource);
-                JObject jsonParse = JObject.Parse(jsonContent);
-                await docGenerator.GenerateFromJson(jsonParse);
+                await docGenerator.GenerateFromJson(jsonContent);
             }
         }
     }


### PR DESCRIPTION
This merges the new feature adding support for creating documentation from a Swagger generated JSON file. Parameter, request, and response objects are broken down into individual property components via bullet points for clearer endpoint requirements and returns. This is now the default option on the UI. CLI execution doesn't change, it will handle the source as a .json file extension or a folder path to the Controller .cs files as before.

Removed support for non-Windows publishing for now. Text file included at root contains the msbuild command to publish as a single file executable.