### PR TITLE
Bug fix for bullet point formatting in MS Word

### DIFF
--- a/Models/DocumentGenerator.cs
+++ b/Models/DocumentGenerator.cs
@@ -555,7 +555,7 @@ namespace APIDocGenerator.Services
 
             ParagraphProperties properties = new ParagraphProperties(new SpacingBetweenLines { After = "0" });
             Paragraph container = new Paragraph(properties);
-            //Run paramSection = container.AppendChild(new Run());
+
             container.AppendChild(Format.CreateBoldTextLine("Parameters", TEXT_FONT_SIZE));
             elements.Add(container);
 
@@ -629,20 +629,20 @@ namespace APIDocGenerator.Services
             if (body.Content.TryGetValue("application/json", out Content? appJsonContent))
             {
                 Run appJson = Format.CreateBoldTextLine("application/json", JSON_FONT_SIZE);
-                Paragraph appJsonParagraph = Format.CreateBulletedListItem(bulletId, 0, appJson);
+                Paragraph appJsonParagraph = Format.CreateBulletedListItem(bulletId, 1, appJson);
                 container.AppendChild(appJsonParagraph);
 
-                Run schemaRun = CreateSchemaFormattedBulletList(1, appJsonContent.Schema, bulletId);
+                Run schemaRun = CreateSchemaFormattedBulletList(2, appJsonContent.Schema, bulletId);
                 container.AppendChild(schemaRun);
             }
 
             if(body.Content.TryGetValue("multipart/form-data", out Content? formData))
             {
                 Run formRun = Format.CreateBoldTextLine("multipart/form-data", JSON_FONT_SIZE);
-                Paragraph formParagraph = Format.CreateBulletedListItem(bulletId, 0, formRun);
+                Paragraph formParagraph = Format.CreateBulletedListItem(bulletId, 1, formRun);
                 container.AppendChild(formParagraph);
 
-                Run schemaRun = CreateSchemaFormattedBulletList(1, formData.Schema, bulletId);
+                Run schemaRun = CreateSchemaFormattedBulletList(2, formData.Schema, bulletId);
                 container.AppendChild(schemaRun);
             }
 
@@ -668,16 +668,16 @@ namespace APIDocGenerator.Services
 
                 int bulletId = CreateNewBulletedList();
                 Run codeRun = Format.CreateLabelValuePair($"{code}: ", responseValue.Description, JSON_FONT_SIZE);
-                Paragraph codeParagraph = Format.CreateBulletedListItem(bulletId, 0, codeRun);
+                Paragraph codeParagraph = Format.CreateBulletedListItem(bulletId, 1, codeRun);
                 container.AppendChild(codeParagraph);
 
                 if (responseValue.Content != null && responseValue.Content.TryGetValue("application/json", out Content? appJsonContent)) 
                 {
                     Run responseTypRun = Format.CreateBoldTextLine("application/json", JSON_FONT_SIZE);
-                    Paragraph responseTypeParagraph  = Format.CreateBulletedListItem(bulletId, 1, responseTypRun);
+                    Paragraph responseTypeParagraph  = Format.CreateBulletedListItem(bulletId, 2, responseTypRun);
                     container.AppendChild(responseTypeParagraph);
 
-                    Run schemaRun = CreateSchemaFormattedBulletList(2, appJsonContent.Schema, bulletId);
+                    Run schemaRun = CreateSchemaFormattedBulletList(3, appJsonContent.Schema, bulletId);
                     container.AppendChild(schemaRun);
                 }
             }

--- a/PublishCmd.txt
+++ b/PublishCmd.txt
@@ -1,1 +1,1 @@
-﻿msbuild /restore /t:Publish /p:TargetFramework=net8.0-windows10.0.19041.0 /p:configuration=release /p:WindowsAppSDKSelfContained=true /p:Platform="Any CPU" /p:PublishSingleFile=true /p:WindowsPackageType=None /p:RuntimeIdentifier=win10-x64
+﻿msbuild /restore /t:Publish /p:TargetFramework=net8.0-windows10.0.19041 /p:configuration=release /p:WindowsAppSDKSelfContained=true /p:Platform="Any CPU" /p:PublishSingleFile=true /p:WindowsPackageType=None /p:RuntimeIdentifier=win10-x64

--- a/Services/FormattingService.cs
+++ b/Services/FormattingService.cs
@@ -41,7 +41,7 @@ namespace APIDocGenerator.Services
             RunProperties textProps = new RunProperties
             {
                 FontSize = new FontSize { Val = fontSize },
-                Bold = new Bold()
+                Bold = new Bold(),
             };
 
             return CreateTextLine(text, textProps);
@@ -59,11 +59,12 @@ namespace APIDocGenerator.Services
         public static Paragraph CreateBulletedListItem(int numberingId, int indent, Run text)
         {
             int indentUnitSize = 240;
-            string indentValue = $"{indent * indentUnitSize}";
+            string indentValue = $"{(indent + 1) * indentUnitSize}";
 
             var propNumberProps = new NumberingProperties(new NumberingLevelReference { Val = 0 }, new NumberingId { Val = numberingId });
             var propSpaceBetween = new SpacingBetweenLines { After = "0" };
-            var propIndentation = new Indentation { Left = indentValue };
+            
+            var propIndentation = new Indentation { Left = indentValue, Hanging = "300" };
 
             Paragraph paragraph = new Paragraph(new ParagraphProperties(propNumberProps, propSpaceBetween, propIndentation));
             paragraph.AppendChild(text);


### PR DESCRIPTION
- Added hanging property to the indent for the bullet point so MS Word would format correctly 
- Adjust indent value on Request Body and Responses so they match parameters
- Changed the indent value to always add 1 to the value passed. Formatting and spacing is wonky and this was easier than going through and further adjusting each indent value by 1.